### PR TITLE
feat: link homepage items to blog

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -354,7 +354,7 @@ export default function Home() {
                 href="/blog"
                 className="inline-block border border-white py-2 px-4 rounded hover:bg-white hover:text-black transition duration-300 relative z-10"
               >
-                Read on the Blog
+                Coming Soon
               </Link>
             </div>
           </div>

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -205,9 +205,12 @@ export default function Home() {
                   A deep dive into scaling applications across multiple regions
                   with Kubernetes...
                 </p>
-                <button className="text-caput-mortuum font-medium flex items-center">
-                  Coming Soon
-                </button>
+                <Link
+                  href="/blog"
+                  className="text-caput-mortuum font-medium flex items-center"
+                >
+                  Read on the Blog
+                </Link>
               </div>
             </div>
 
@@ -231,9 +234,12 @@ export default function Home() {
                   How to align your communication style with global engineering
                   teams...
                 </p>
-                <button className="text-caput-mortuum font-medium flex items-center">
-                  Coming Soon
-                </button>
+                <Link
+                  href="/blog"
+                  className="text-caput-mortuum font-medium flex items-center"
+                >
+                  Read on the Blog
+                </Link>
               </div>
             </div>
 
@@ -257,9 +263,12 @@ export default function Home() {
                   Key architectural thinking patterns that separate mid-level
                   from senior engineers...
                 </p>
-                <button className="text-caput-mortuum font-medium flex items-center">
-                  Coming Soon
-                </button>
+                <Link
+                  href="/blog"
+                  className="text-caput-mortuum font-medium flex items-center"
+                >
+                  Read on the Blog
+                </Link>
               </div>
             </div>
           </div>
@@ -285,9 +294,12 @@ export default function Home() {
               <div className="absolute bottom-[-20px] right-[-20px] text-caput-mortuum opacity-10 text-8xl">
                 <FaServer />
               </div>
-              <button className="inline-block border border-white py-2 px-4 rounded hover:bg-white hover:text-black transition duration-300 relative z-10">
-                Coming Soon
-              </button>
+              <Link
+                href="/blog"
+                className="inline-block border border-white py-2 px-4 rounded hover:bg-white hover:text-black transition duration-300 relative z-10"
+              >
+                Read on the Blog
+              </Link>
             </div>
 
             <div className="bg-caput-mortuum bg-opacity-30 p-6 rounded-lg shadow-lg transition duration-300 hover:-translate-y-2 border border-gray-800 relative overflow-hidden">
@@ -301,9 +313,12 @@ export default function Home() {
               <div className="absolute bottom-[-20px] right-[-20px] text-caput-mortuum opacity-10 text-8xl">
                 <FaEarthAfrica />
               </div>
-              <button className="inline-block border border-white py-2 px-4 rounded hover:bg-white hover:text-black transition duration-300 relative z-10">
-                Coming Soon
-              </button>
+              <Link
+                href="/blog"
+                className="inline-block border border-white py-2 px-4 rounded hover:bg-white hover:text-black transition duration-300 relative z-10"
+              >
+                Read on the Blog
+              </Link>
             </div>
 
             <div className="bg-caput-mortuum bg-opacity-30 p-6 rounded-lg shadow-lg transition duration-300 hover:-translate-y-2 border border-gray-800 relative overflow-hidden">
@@ -317,9 +332,12 @@ export default function Home() {
               <div className="absolute bottom-[-20px] right-[-20px] text-caput-mortuum opacity-10 text-8xl">
                 <FaArrowUpRightDots />
               </div>
-              <button className="inline-block border border-white py-2 px-4 rounded hover:bg-white hover:text-black transition duration-300 relative z-10">
-                Coming Soon
-              </button>
+              <Link
+                href="/blog"
+                className="inline-block border border-white py-2 px-4 rounded hover:bg-white hover:text-black transition duration-300 relative z-10"
+              >
+                Read on the Blog
+              </Link>
             </div>
 
             <div className="bg-caput-mortuum bg-opacity-30 p-6 rounded-lg shadow-lg transition duration-300 hover:-translate-y-2 border border-gray-800 relative overflow-hidden">
@@ -332,9 +350,12 @@ export default function Home() {
               <div className="absolute bottom-[-20px] right-[-20px] text-caput-mortuum opacity-10 text-8xl">
                 <FaUsers />
               </div>
-              <button className="inline-block border border-white py-2 px-4 rounded hover:bg-white hover:text-black transition duration-300 relative z-10">
-                Coming Soon
-              </button>
+              <Link
+                href="/blog"
+                className="inline-block border border-white py-2 px-4 rounded hover:bg-white hover:text-black transition duration-300 relative z-10"
+              >
+                Read on the Blog
+              </Link>
             </div>
           </div>
         </div>

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -206,7 +206,7 @@ export default function Home() {
                   with Kubernetes...
                 </p>
                 <Link
-                  href="/blog"
+                  href="/blog/architecting-multi-region-kubernetes-deployments-beyond-basic-replication"
                   className="text-caput-mortuum font-medium flex items-center"
                 >
                   Read on the Blog
@@ -235,7 +235,7 @@ export default function Home() {
                   teams...
                 </p>
                 <Link
-                  href="/blog"
+                  href="/blog/communication-patterns-that-global-teams-expect"
                   className="text-caput-mortuum font-medium flex items-center"
                 >
                   Read on the Blog
@@ -264,7 +264,7 @@ export default function Home() {
                   from senior engineers...
                 </p>
                 <Link
-                  href="/blog"
+                  href="/blog/system-design-skills-that-show-you-re-senior-ready"
                   className="text-caput-mortuum font-medium flex items-center"
                 >
                   Read on the Blog


### PR DESCRIPTION
## Summary
- replace placeholder Coming Soon buttons with links to the blog

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Invalid ESLint options)
- `npm run build` (fails: Configuration must contain `projectId`)


------
https://chatgpt.com/codex/tasks/task_e_68a82aaa39808330ae0677e8472c6794